### PR TITLE
CATv2 API changes

### DIFF
--- a/utils/cat_helper.py
+++ b/utils/cat_helper.py
@@ -37,59 +37,114 @@ class CatQuery(object):
         response = "<?xml version='1.0' ?><CAT-API-Response>"+response
         return response
 
+    """ Send a CATv2 API request """
+    def v2api_request(self, verb, params):
+        apiRequest = {
+            "ACTION": verb,
+            "APIKEY": self.key,
+            "PARAMETERS": params
+        }
+        r = requests.post(self.url, json=apiRequest)
+        try:
+            return r.json()
+        except ValueError:
+            return r.content
+
+    ''' This is necessary to avoid rewriting other parts of DjNRO. It
+    effectively munges the CATv1 API's parameter format into CATv2 JSON.
+    Ironically CATv2 currently does the inverse and this is a counterpart
+    to the uglify() method at https://github.com/GEANT/CAT/blob/master/web/lib/admin/API.php
+    '''
+    def deuglify(self, kwargs):
+        params = [None]*(len(kwargs)/2);
+        for k in sorted(kwargs, key=string_split_by_numbers):
+            m = re.search(r"\[S(\d+)", k);
+            id = 0
+            if m:
+                id = int(m.group(1))
+            if k.startswith('option[S'):
+                params[id] = dict()
+                params[id]['NAME'] = kwargs[k]
+            elif k.startswith('value[S'):
+                if k.endswith('-lang]'):
+                    if kwargs[k] != 'C':
+                        params[id]['LANG'] = kwargs[k]
+                else:
+                    params[id]['VALUE'] = kwargs[k]
+        return filter(None, params)
+
+    """ Add an administrator into an institution """
+    def adminadd(self, kwargs):
+        self.status = None
+        self.response = None
+        if 'NEWINST_PRIMARYADMIN' not in kwargs.keys():
+            raise Exception('NEWINST_PRIMARYADMIN parameter is missing')
+        response = self.v2api_request('ADMIN-ADD', [
+            {
+                'NAME': 'ATTRIB-ADMINID',
+                'VALUE': kwargs['NEWINST_PRIMARYADMIN'],
+            },
+            {
+                'NAME': 'ATTRIB-CAT-INSTID',
+                'VALUE': kwargs['INST_IDENTIFIER'],
+            },
+            {
+                'NAME': 'ATTRIB-TARGETMAIL',
+                'VALUE': kwargs['NEWINST_PRIMARYADMIN'],
+            },
+        ])
+        if 'result' in response and response['result'] == 'SUCCESS':
+            self.status = 'Success'
+            self.response = {
+                "inst_unique_id": kwargs['INST_IDENTIFIER'],
+                "enrollment_URL": response['details']['TOKEN URL'],
+                "enrollment_token": response['details']['TOKEN']
+            }
+            return True
+        else:
+            self.status = 'Error'
+            self.response = response['details']['description']
+            return False
+
+    """ Create a new institution, optionally adding an administrator to emulate the v1 behaviour. """
     def newinst(self, kwargs):
         self.status = None
         self.response = None
-        kwargs['ACTION'] = 'NEWINST'
-        if 'NEWINST_PRIMARYADMIN' not in kwargs.keys():
-            raise Exception('NEWINST_PRIMARYADMIN parameter is missing')
-        response = self.post_request(kwargs)
-        r = objectify.fromstring(response)
-        try:
-            assert r.success is not None
-            # Successfull response
-            self.status = 'Success'
-            self.response = {
-                "inst_unique_id": r.success.inst_unique_id,
-                "enrollment_URL": r.success.enrollment_URL
-            }
-            return True
-        except AttributeError:
+        params = self.deuglify(kwargs);
+        response = self.v2api_request('NEWINST', params)
+        if 'result' in response and response['result'] == 'SUCCESS':
+            kwargs['INST_IDENTIFIER'] = response['details']['ATTRIB-CAT-INSTID']
+            if 'NEWINST_PRIMARYADMIN' in kwargs.keys():
+                return self.adminadd(kwargs)
+            else:
+                self.status = 'Success'
+                self.response = {
+                    "inst_unique_id": response['details']['ATTRIB-CAT-INSTID']
+                }
+                return True
+        else:
             self.status = 'Error'
-            self.response = r.error.description
+            self.response = response['details']['description']
             return False
 
+    """ Emulate the v1 ADMINCOUNT function from ADMIN-LIST """
     def admincount(self, kwargs):
         self.status = None
         self.response = None
-        kwargs['ACTION'] = 'ADMINCOUNT'
         if not 'INST_IDENTIFIER' in kwargs.keys():
             raise Exception('INST_IDENTIFIER parameter is missing')
-        response = self.post_request(kwargs)
-        response = self.curate_response(response)
-        r = objectify.fromstring(response)
-        try:
-            assert r.success is not None
-            # Successfull response
+        response = self.v2api_request('ADMIN-LIST', [ { 'NAME': 'ATTRIB-CAT-INSTID', 'VALUE': kwargs['INST_IDENTIFIER'] } ])
+        if 'result' in response and response['result'] == 'SUCCESS':
             self.status = 'Success'
-            self.response = {"number_of_admins":r.success.number_of_admins}
+            self.response = {"number_of_admins": len(response['details'])}
             return True
-        except AttributeError:
+        else:
             self.status = 'Error'
-            self.response = r.error.description
+            self.response = response['details']['description']
             return False
 
     def statistics(self):
         self.status = None
         self.response = None
-        kwargs = {}
-        kwargs['ACTION'] = 'STATISTICS'
-        response = self.post_request(kwargs)
-        response = self.curate_response(response)
-        r = objectify.fromstring(response)
-        return r
-
-
-
-
-
+        response = self.v2api_request('STATISTICS-FED', None)
+        return response['details']


### PR DESCRIPTION
With the release of CAT 2.0-beta1 comes a significant change in the CAT [admin API](https://github.com/GEANT/CAT/blob/master/Changes.md). This change is not [backwards compatible](https://wiki.geant.org/display/H2eduroam/A+guide+to+eduroam+CAT+2.0+and+eduroam+Managed+IdP+for+National+Roaming+Operator+administrators#AguidetoeduroamCAT2.0andeduroamManagedIdPforNationalRoamingOperatoradministrators-UI-lessAutomatedManagement:theAdminAPI(2.0)), and the old API version is no longer supported in production.

DjNRO abstracts its CAT API calls into a `CatQuery` class, but the parameters passed to functions in this class are explicitly derived from v1 of the CAT API. This change introduces support for the CATv2 admin API while preserving the DjNRO `CatQuery` abstraction interface. By doing this, we avoid making changes to other parts of the DjNRO code base at the expense of slightly complicating the `CatQuery` class.

Part of the reason I've elected to do things in this way is that the `CatQuery` class contains functions and static methods that are not called from elsewhere within the published DjNRO code base, making it unclear as to why they exist -- and leading to the assumption that they're used by other, unpublished utilities.